### PR TITLE
Add placeholder index page for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>R. Calen Walshe</title>
+</head>
+<body>
+  <h1>R. Calen Walshe</h1>
+  <p>This repository hosts the source for my personal site.</p>
+  <p>Until the full site is deployed, you can view the generated content in the <a href="public/">public</a> folder.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `index.html` so GitHub Pages shows content

## Testing
- `git status --short`