### PR TITLE
Fix GitHub Pages configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+public/

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,11 @@ title = "R. Calen Walshe"
 
 # The URL of your site.
 # End your URL with a `/` trailing slash, e.g. `https://example.com/`.
-baseurl = "calenwalshe.github.io"
+baseurl = "https://calenwalshe.github.io/"
+
+# Directory to publish the built site to. GitHub Pages can serve from the
+# `docs` folder, so publish there instead of the default `public` directory.
+publishDir = "docs"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`. For current year, type `{year}`.

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -10,7 +10,11 @@ title = "R. Calen Walshe"
 
 # The URL of your site.
 # End your URL with a `/` trailing slash, e.g. `https://example.com/`.
-baseurl = "/"
+baseurl = "https://calenwalshe.github.io/"
+
+# Directory to publish the built site to. GitHub Pages can serve from the
+# `docs` folder, so publish there instead of the default `public` directory.
+publishDir = "docs"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`. For current year, type `{year}`.


### PR DESCRIPTION
## Summary
- adjust base URL for GitHub Pages
- publish site to `docs` directory
- ignore `public/` build artifacts

## Testing
- `hugo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e827897fc8324a14a4e317d23bbec