### PR TITLE
Inline CSS/JS for index

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,20 @@
+{{- define "main" -}}
+
+{{/* Check that user fully installed Academic. */}}
+{{ if not (isset site.Params "theme") }}
+  {{ errorf "Please complete the installation of Academic by following the steps at https://sourcethemes.com/academic/docs/install/" }}
+{{ end }}
+
+{{/* Deprecation warnings */}}
+
+{{/* v4.5: Address changed from string to map. */}}
+{{ if isset site.Params "address" }}
+{{ if eq (reflect.IsMap site.Params.address) false }}
+  {{ errorf "Please upgrade the `address` field in `config/_default/params.toml`. Refer to all of the Breaking Changes in v4.5 at https://sourcethemes.com/academic/updates/v4.5.0/" }}
+{{ end }}
+{{ end }}
+
+{{/* Generate homepage. */}}
+{{ partial "widget_page.html" . }}
+
+{{- end -}}

--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -1,0 +1,31 @@
+<footer class="site-footer">
+  {{ if or (site.GetPage "terms.md") (site.GetPage "privacy.md") }}
+  <p class="powered-by">
+    {{ with site.GetPage "privacy.md" }}
+      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ end }}
+    {{ with site.GetPage "terms.md" }}
+      {{ if site.GetPage "privacy.md" }} &middot; {{ end }}
+      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ end }}    
+  </p>
+  {{ end }}
+
+  <p class="powered-by">
+    {{ with site.Copyright }}{{ replace . "{year}" now.Year | markdownify}} &middot; {{ end }}
+
+    Powered by the
+    <a href="https://sourcethemes.com/academic/" target="_blank" rel="noopener">Academic theme</a> for
+    <a href="https://gohugo.io" target="_blank" rel="noopener">Hugo</a>.
+
+    {{ if ne .Type "docs" }}
+    <span class="float-right" aria-hidden="true">
+      <a href="#" id="back_to_top">
+        <span class="button_icon">
+          <i class="fas fa-chevron-up fa-2x"></i>
+        </span>
+      </a>
+    </span>
+    {{ end }}
+  </p>
+</footer>

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -1,0 +1,176 @@
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
+
+  {{ $scr := .Scratch }}
+
+  {{/* Attempt to load superuser. */}}
+  {{ $superuser_name := "" }}
+  {{ $superuser_username := "" }}
+  {{ $superuser_role := "" }}
+  {{ range first 1 (where (where site.Pages "Section" "authors") "Params.superuser" true) }}
+    {{ $superuser_name = .Params.name }}
+    {{ $superuser_username = path.Base (path.Split .Path).Dir }}
+    {{ $superuser_role = .Params.role }}
+  {{ end }}
+  {{ $scr.Set "superuser_username" $superuser_username }}{{/* Set superuser globally for page_author.html. */}}
+
+  {{ with $superuser_name }}<meta name="author" content="{{ . }}">{{ end }}
+
+  {{/* Generate page description. */}}
+  {{ $desc := "" }}
+  {{ if .Params.summary }}
+    {{ $desc = .Params.summary }}
+  {{ else if .Params.abstract }}
+    {{ $desc = .Params.abstract }}
+  {{ else if .IsPage }}
+    {{ $desc = .Summary }}
+  {{ else if site.Params.description }}
+    {{ $desc = site.Params.description }}
+  {{ else }}
+    {{ $desc = $superuser_role }}
+  {{ end }}
+  <meta name="description" content="{{ $desc }}">
+
+  {{ range .Translations }}
+  <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
+  {{ end }}
+  <link rel="alternate" hreflang="{{ site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}">
+
+  {{ partial "functions/parse_theme" . }}
+  {{ $css := site.Data.assets.css }}
+  {{ $js := site.Data.assets.js }}
+  {{ if ne ($scr.Get "primary") "#fff" }}
+  <meta name="theme-color" content="{{ $scr.Get "primary" }}">
+  {{ end }}
+
+  {{/* Attempt to load local vendor CSS, otherwise load from CDN. */}}
+  {{ $scr.Set "vendor_css_filename" "main.min.css" }}
+  {{ $scr.Set "vendor_js_filename" "main.min.js" }}
+  {{ if and (fileExists (printf "static/css/vendor/%s" ($scr.Get "vendor_css_filename"))) (fileExists (printf "static/js/vendor/%s" ($scr.Get "vendor_js_filename"))) }}
+    {{ $scr.Set "use_cdn" 0 }}
+    <link rel="stylesheet" href="{{ printf "/css/vendor/%s" ($scr.Get "vendor_css_filename") | relURL }}">
+  {{ else }}
+    {{ $scr.Set "use_cdn" 1 }}
+    {{ $academicons := resources.GetRemote (printf $css.academicons.url $css.academicons.version) }}<style>{{ $academicons.Content | safeCSS }}</style>
+    {{ $fontAwesome := resources.GetRemote (printf $css.fontAwesome.url $css.fontAwesome.version) }}<style>{{ $fontAwesome.Content | safeCSS }}</style>
+    {{ $fancybox := resources.GetRemote (printf $css.fancybox.url $css.fancybox.version) }}<style>{{ $fancybox.Content | safeCSS }}</style>
+
+    {{/* Default to enabling highlighting, but allow the user to override it in .Params or site.Params.
+         Use $scr to store "highlight_enabled", so that we can read it again in footer.html. */}}
+    {{ $scr.Set "highlight_enabled" true }}
+    {{ if isset .Params "highlight" }}
+      {{ $scr.Set "highlight_enabled" .Params.highlight }}
+    {{ else if isset site.Params "highlight" }}
+      {{ $scr.Set "highlight_enabled" site.Params.highlight }}
+    {{ end }}
+    {{ if ($scr.Get "highlight_enabled") }}
+      {{ $v := $css.highlight.version }}
+      {{ with site.Params.highlight_style }}
+    <!-- highlight styles omitted -->
+      {{ end }}
+    {{ end }}
+
+    {{ if or (eq site.Params.map.engine 2) (eq site.Params.map.engine 3) }}
+    {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.leaflet.url $css.leaflet.version) $css.leaflet.sri | safeHTML }}
+    {{ end }}
+
+    {{ if eq site.Params.search.engine 2 }}
+      {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.instantsearch.url $css.instantsearch.version) $css.instantsearch.sri | safeHTML }}
+      {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.instantsearchTheme.url $css.instantsearchTheme.version) $css.instantsearchTheme.sri | safeHTML }}
+    <!-- other remote css omitted -->
+    {{ $css_bundle_head := $css_comment | resources.FromString "css/bundle-head.css" }}
+    {{ $css_bundle := slice }}
+    {{ range site.Params.plugins_css }}
+      {{ $css_bundle = $css_bundle | append (resources.Get (printf "css/%s.css" .)) }}
+    {{ end }}
+    {{ $css_bundle := $css_bundle | resources.Concat "css/academic-bundle-pre.css" | minify }}
+    {{ $css_bundle := slice $css_bundle_head $css_bundle | resources.Concat "css/academic.css" | fingerprint "md5" }}
+    <style>{{ $css_bundle.Content | safeCSS }}</style>
+  {{ end }}
+
+  {{ if not site.IsServer }}
+  {{ if site.GoogleAnalytics }}
+    <script>
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', '{{ site.GoogleAnalytics }}', 'auto');
+      {{ if site.Params.privacy_pack }}ga('set', 'anonymizeIp', true);{{ end }}
+      ga('require', 'eventTracker');
+      ga('require', 'outboundLinkTracker');
+      ga('require', 'urlChangeTracker');
+      ga('send', 'pageview');
+    </script>
+    <!-- analytics script omitted -->
+    {{ if ($scr.Get "use_cdn") }}
+    <!-- autotrack omitted -->
+    {{ end }}
+  {{ end }}
+  {{ end }}
+
+  {{ with .OutputFormats.Get "RSS" }}
+  <link rel="alternate" href="{{.RelPermalink}}" type="application/rss+xml" title="{{site.Title}}">
+  {{ end }}
+
+  <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
+  <link rel="icon" type="image/png" href="{{ "img/icon-32.png" | relURL }}">
+  <link rel="apple-touch-icon" type="image/png" href="{{ "img/icon-192.png" | relURL }}">
+
+  <link rel="canonical" href="{{ .Permalink }}">
+
+  {{ $featured_image := (.Resources.ByType "image").GetMatch "*featured*" }}
+  {{ $og_image := "" }}
+  {{ $twitter_card := "summary_large_image" }}
+  {{ if $featured_image }}
+    {{ $og_image = $featured_image.Permalink }}
+  {{ else if .Params.header.image }}
+    {{ $og_image = printf "img/%s" .Params.header.image | absURL }}
+  {{ else if site.Params.sharing_image }}
+    {{ $og_image = printf "img/%s" site.Params.sharing_image | absURL }}
+  {{ else if site.Params.logo }}
+    {{ $og_image = (printf "img/%s" site.Params.logo) | absURL }}
+    {{ $twitter_card = "summary" }}
+  {{ else if site.Params.avatar }}
+    {{ $og_image = (printf "img/%s" site.Params.avatar) | absURL }}
+    {{ $twitter_card = "summary" }}
+  {{ else }}
+    {{ $og_image = "img/icon-192.png" | absURL }}
+    {{ $twitter_card = "summary" }}
+  {{ end }}
+  {{ $scr.Set "og_image" $og_image }}{{/* Set `og_image` globally for `rss.xml`. */}}
+  <meta property="twitter:card" content="{{ $twitter_card }}">
+  {{ with site.Params.twitter }}
+  <meta property="twitter:site" content="@{{ . }}">
+  <meta property="twitter:creator" content="@{{ . }}">
+  {{ end }}
+  <meta property="og:site_name" content="{{ site.Title }}">
+  <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:title" content="{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ site.Title }}">
+  <meta property="og:description" content="{{ $desc }}">
+  {{- with $og_image -}}
+  <meta property="og:image" content="{{.}}">
+  <meta property="twitter:image" content="{{.}}">
+  {{- end -}}
+  <meta property="og:locale" content="{{ site.LanguageCode | default "en-us" }}">
+  {{ if .IsPage }}
+    {{ if not .PublishDate.IsZero }}
+      <meta property="article:published_time" content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">
+    {{ else if not .Date.IsZero }}
+      <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">
+    {{ end }}
+    {{ if not .Lastmod.IsZero }}<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">{{ end }}
+  {{ else }}
+    {{ if not .Date.IsZero }}<meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">{{ end }}
+  {{ end }}
+
+  {{ partial "jsonld/main" (dict "page" . "summary" $desc) }}
+
+  {{ partial "cookie_consent" . }}
+
+  {{ partial "custom_head" . }}
+
+  <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ site.Title }}</title>
+
+</head>

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -1,0 +1,152 @@
+    {{ $scr := $.Scratch }}
+
+    {{/* Config LaTeX math rendering. */}}
+    {{ if or .Params.math site.Params.math }}
+    {{ $mathjax_config := resources.Get "js/mathjax-config.js" }}
+    <script>{{ $mathjax_config.Content | safeJS }}</script>
+    {{ end }}
+
+    {{/* Attempt to load local vendor JS, otherwise load from CDN. */}}
+    {{ $js := site.Data.assets.js }}
+    {{ if not ($scr.Get "use_cdn") }}
+      <script>{{ (resources.Get (printf "js/vendor/%s" ($scr.Get "vendor_js_filename"))).Content | safeJS }}</script>
+    {{ else }}
+      <!-- jQuery omitted -->
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.imagesLoaded.url $js.imagesLoaded.version) $js.imagesLoaded.sri | safeHTML }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.isotope.url $js.isotope.version) $js.isotope.sri | safeHTML }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.fancybox.url $js.fancybox.version) $js.fancybox.sri | safeHTML }}
+
+      {{ if or .Params.diagram site.Params.diagram }}
+        {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\" title=\"mermaid\"></script>" (printf $js.mermaid.url $js.mermaid.version) $js.mermaid.sri | safeHTML }}
+      {{ end }}
+
+      {{ if $.Scratch.Get "highlight_enabled" }}
+        {{ $v := $js.highlight.version }}
+        {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.highlight.url $v) $js.highlight.sri | safeHTML }}
+        {{ range site.Params.highlight_languages }}
+        <!-- highlight languages omitted -->
+        {{ end }}
+      {{ end }}
+
+      {{/* LaTeX math rendering. */}}
+      {{ if or .Params.math site.Params.math }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\" async></script>" (printf $js.mathJax.url $js.mathJax.version) $js.mathJax.sri | safeHTML }}
+      {{ end }}
+    {{ end }}
+
+    {{/* Maps JS. */}}
+    {{ if eq site.Params.map.engine 1 }}
+      <!-- google maps omitted -->
+      {{ if ($scr.Get "use_cdn") }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.gmaps.url $js.gmaps.version) $js.gmaps.sri | safeHTML }}
+      {{ end }}
+    {{ else if and (or (eq site.Params.map.engine 2) (eq site.Params.map.engine 3)) ($scr.Get "use_cdn") }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.leaflet.url $js.leaflet.version) $js.leaflet.sri | safeHTML }}
+    {{ end }}
+
+    {{/* Initialise code highlighting. */}}
+    {{ if $.Scratch.Get "highlight_enabled" }}
+    <script>hljs.initHighlightingOnLoad();</script>
+    {{ end }}
+
+    {{ if ne site.Params.search.engine 0 }}
+    {{/* Configure search engine. */}}
+    <script>
+      const search_index_filename = {{ "/index.json" | relLangURL }};
+      const i18n = {
+        'placeholder': {{ i18n "search_placeholder" }},
+        'results': {{ i18n "search_results" }},
+        'no_results': {{ i18n "search_no_results" }}
+      };
+      const content_type = {
+        'post': {{ i18n "posts" }},
+        'project': {{ i18n "projects" }},
+        'publication' : {{ i18n "publications" }},
+        'talk' : {{ i18n "talks" }}
+        };
+    </script>
+    {{ end }}
+
+    {{/* Load hash anchors for documentation pages. */}}
+    {{ if eq .Type "docs" }}
+    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.anchor.url $js.anchor.version) $js.anchor.sri | safeHTML }}
+    <script>
+      anchors.add();
+    </script>
+    {{ end }}
+
+    {{ if eq site.Params.search.engine 1 }}
+    {{/* Fuse search result template. */}}
+    <script id="search-hit-fuse-template" type="text/x-template">
+      <div class="search-hit" id="summary-{{"{{key}}"}}">
+      <div class="search-hit-content">
+        <div class="search-hit-name">
+          {{ printf "<a href=\"%s\">%s</a>" "{{relpermalink}}" "{{title}}" | safeHTML }}
+          <div class="article-metadata search-hit-type">{{"{{type}}"}}</div>
+          <p class="search-hit-description">{{"{{snippet}}"}}</p>
+        </div>
+      </div>
+      </div>
+    </script>
+    {{ else if eq site.Params.search.engine 2 }}
+    {{/* Algolia search result template. */}}
+    <script id="search-hit-algolia-template" type="text/html">
+      <div class="search-hit">
+        <div class="search-hit-content">
+          <div class="search-hit-name">
+            {{ printf "<a href=\"%s\">{{{_highlightResult.title.value}}}</a>" "{{relpermalink}}" | safeHTML }}
+          </div>
+          <div class="article-metadata search-hit-type">{{"{{type}}"}}</div>
+          <p class="search-hit-description">{{ safeHTML "{{{_highlightResult.summary.value}}}" }}</p>
+        </div>
+      </div>
+    </script>
+    {{ end }}
+
+    {{/* Fuse search engine. */}}
+    {{ if and (eq site.Params.search.engine 1) ($scr.Get "use_cdn") }}
+    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.fuse.url $js.fuse.version) $js.fuse.sri | safeHTML }}
+    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.mark.url $js.mark.version) $js.mark.sri | safeHTML }}
+    {{ end }}
+
+    {{/* Algolia search engine. */}}
+    {{ if eq site.Params.search.engine 2 }}
+    {{ if ($scr.Get "use_cdn") }}
+    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.instantsearch.url $js.instantsearch.version) $js.instantsearch.sri | safeHTML }}
+    {{ end }}
+    <script>
+      const algoliaConfig = {
+        appId: {{ site.Params.search.algolia.app_id }},
+        apiKey: {{ site.Params.search.algolia.api_key }},
+        indexName: {{ site.Params.search.algolia.index_name }},
+        poweredBy: {{ site.Params.search.algolia.show_logo | default false }}
+      };
+    </script>
+    {{ end }}
+
+    {{/* Disqus Comment Count JS. */}}
+    {{ if and (eq site.Params.comments.engine 1) (site.Params.comments.disqus.show_count | default true) }}
+    <!-- disqus count omitted -->
+    {{ end }}
+
+    {{ $js_comment := printf "/* Source Themes Academic v%s | https://sourcethemes.com/academic/ */\n" site.Data.academic.version }}
+    {{ $js_bundle_head := $js_comment | resources.FromString "js/bundle-head.js" }}
+    {{ $js_linebreak := "\n" | resources.FromString "js/linebreak.js" }}{{/* Fix no line break after Bootstrap JS causing error. */}}
+    {{ $js_academic := resources.Get "js/academic.js" }}
+    {{ $js_academic_search := resources.Get "js/academic-search.js" }}
+    {{ $js_algolia_search := resources.Get "js/algolia-search.js" }}
+    {{ $js_bootstrap := resources.Get "js/vendor/bootstrap.min.js" }}
+    {{ $js_bundle := slice $js_bootstrap $js_linebreak $js_academic }}
+    {{ if eq site.Params.search.engine 1 }}
+      {{ $js_bundle = $js_bundle | append $js_academic_search }}
+    {{ else if eq site.Params.search.engine 2 }}
+      {{ $js_bundle = $js_bundle | append $js_algolia_search }}
+    {{ end }}
+    {{ range site.Params.plugins_js }}
+      {{ $js_bundle = $js_bundle | append (resources.Get (printf "js/%s.js" .)) }}
+    {{ end }}
+    {{ $js_bundle := $js_bundle | resources.Concat "js/academic-bundle-pre.js" | minify }}
+    {{ $js_bundle := slice $js_bundle_head $js_bundle | resources.Concat "js/academic.min.js" | fingerprint "md5" }}
+    <script>{{ $js_bundle.Content | safeJS }}</script>
+
+    {{ partial "custom_js" . }}


### PR DESCRIPTION
## Summary
- copy theme index and partials to allow customization
- inline CSS bundles in `site_head.html`
- inline JS bundle and MathJax configuration in `site_js.html`
- leave placeholders for remote analytics and other assets

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ea4a117608324973bdd9d2b6dbf9f